### PR TITLE
Handle Deleted Rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 ### Changed
+- Fixed handling of deleted rows. Closes #1.
 - Fixed a `ResourceWarning: unclosed file`, close the DB file after reading it into memory.
 
 ## [1.0.1] - 2021-09-11

--- a/NOTES.md
+++ b/NOTES.md
@@ -43,3 +43,18 @@ Datatypes
 | 7  | Double    | 8 | IEEE-754  |
 | 11 | Timestamp | 8 | IEEE-754, milliseconds since [AD 1, Jan 0](https://en.wikipedia.org/wiki/List_of_non-standard_dates#January_0) |
 | 5383 | Currency | 8 | IEEE-754  |
+
+
+Row Definition
+--------------
+
+A row in the actual data section of the database has a 26-byte row header. The main field is the first one which denotes that the row has been deleted (deleted rows may be overwritten later but the data remains in-place).
+
+|  Offset  | Size<br>(bytes) | Description |
+|  ------: | ---- | ---------------------- |
+|  `0x0`   | 2    | Row is deleted (=1)    |
+|  `0x2`   | 2    | Index A (Starts at 1)  |
+|  `0x5`   | 2    | Index B (Starts at 1)  |
+|  `0x9`   | 16   | Checksum (MD5?)        |
+|  `0x19`  | 2    | Trailing `\x01` marker |
+|  `0x20`  |      | Start of first field   |

--- a/pydbisam/__init__.py
+++ b/pydbisam/__init__.py
@@ -78,10 +78,11 @@ class PyDBISAM(object):
         print(f"  Total Fields: {self.total_fields}")
         print(f"      Row Size: {self.row_size}")
         print(f"    Total Rows: {self.total_rows}")
+        print(f"  Deleted Rows: {self._deleted_rows}")
         print()
         print(f"  Column Info Offset: {self._FIELD_INFO_OFFSET}")
         print(f"         Data Offset: {self._data_offset}")
-        print(f"           Data Size: {self._data_size}")
+        print(f"  Calc Row Area Size: {self._calc_row_area_size}")
         print(f"         File Length: {len(self._data)}")
         print()
 

--- a/pydbisam/__init__.py
+++ b/pydbisam/__init__.py
@@ -100,5 +100,7 @@ class PyDBISAM(object):
         return [x.name for x in self._columns]
 
     def rows(self):
-        for index in range(self._total_rows):
-            yield self.row(index)
+        for index in range(self._total_rows + self._deleted_rows):
+            row_values = self.row(index)
+            if row_values is not None:
+                yield row_values

--- a/pydbisam/extract.py
+++ b/pydbisam/extract.py
@@ -55,7 +55,8 @@ def _read_file_header(self):
         raise IOError(
             "The actual file size is less than expected. "
             "It should be equal to or greater than calculated size.\n"
-            f"Calculated = {calc_size} = {self._FIELD_INFO_OFFSET} + {field_info_subheader_size} + {self._calc_row_area_size}\n"
+            f"Calculated = {calc_file_size} = "
+            f"{self._FIELD_INFO_OFFSET} + {field_info_subheader_size} + {self._calc_row_area_size}\n"
             f"Actual     = {meas_file_size}\n"
             f"Diff       = {meas_file_size - calc_file_size}"
         )
@@ -118,9 +119,9 @@ def row(self, index, extract_deleted=False):
     row_deleted = struct.unpack_from("<B", row_header_data, 0x0)[0]
 
     # Not sure the exact behavior of these indexes
-    row_idx_a = struct.unpack_from("<B", row_header_data, 0x1)[0]
-    row_idx_b = struct.unpack_from("<B", row_header_data, 0x5)[0]
-    row_checksum = row_header_data[0x9 : 0x9 + 16]
+    # row_idx_a = struct.unpack_from("<B", row_header_data, 0x1)[0]
+    # row_idx_b = struct.unpack_from("<B", row_header_data, 0x5)[0]
+    # row_checksum = row_header_data[0x9 : 0x9 + 16]
 
     if row_deleted and not extract_deleted:
         return None


### PR DESCRIPTION
Actually handle deleted rows.

- Calculates deleted rows during initial loading of the database.
- `PyDBISAM.row(..)` will return `None` if an attempt to retrieve a row that is marked as deleted. This behavior can be override by passing in `extract_deleted=True` which will return the data in that deleted row.
- `PyDBISAM.rows()` will return only non-deleted rows.

Closes #1.